### PR TITLE
Bug-2026039444-htmlclient-formatpattern-regex

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.fs.htmlclient"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10061
-        versionName "1.0.61"
+        versionCode 10062
+        versionName "1.0.62"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "htmlclient",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "htmlclient",
-      "version": "1.0.61",
+      "version": "1.0.62",
       "license": "none",
       "dependencies": {
         "@angular/animations": "20.3.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htmlclient",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "description": "Framework Studio HTML Client",
   "repository": "npm/npm",
   "private": true,

--- a/src/app/common/property-data.ts
+++ b/src/app/common/property-data.ts
@@ -125,6 +125,7 @@ export class PropertyData {
   public fieldRowSize?: number;
   public format?: TextFormat;
   public formatPattern?: string;
+  public isFormatPatternRegex?: boolean;
   public hideModalHeader?: boolean;
   public invertFlowDirection?: boolean;
   public isCloseIconVisible?: boolean;

--- a/src/app/common/property-store.ts
+++ b/src/app/common/property-store.ts
@@ -1132,6 +1132,11 @@ export class PropertyStore {
     });
   }
 
+  // IsFormatPatternRegex
+  public getIsFormatPatternRegex(): boolean {
+    return this.getValue<boolean | undefined>((data: PropertyData) => data.isFormatPatternRegex) === true;
+  }
+
   // InvertFlowDirection
   public getInvertFlowDirection(): boolean | undefined {
     return this.getValue<boolean | undefined>((data: PropertyData) => data.invertFlowDirection);

--- a/src/app/controls/textboxes/textbox-plain/textbox-plain.component.ts
+++ b/src/app/controls/textboxes/textbox-plain/textbox-plain.component.ts
@@ -2,7 +2,11 @@ import { CommonModule } from '@angular/common';
 import { Component, ElementRef, inject, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TextBoxComponent } from '@app/controls/textboxes/textbox.component';
+import { MsgBoxButtons } from '@app/enums/msgbox-buttons';
+import { MsgBoxDefaultButton } from '@app/enums/msgbox-defaultbutton';
+import { MsgBoxIcon } from '@app/enums/msgbox-icon';
 import { TextFormat } from '@app/enums/text-format';
+import { DialogService } from '@app/services/dialog.service';
 import { StringFormatService } from '@app/services/formatter/string-format.service';
 import { TextBoxPlainWrapper } from '@app/wrappers/textbox-plain-wrapper';
 
@@ -24,7 +28,9 @@ export class TextBoxPlainComponent extends TextBoxComponent {
   public isPasswordField: boolean = false;
 
   private _format: TextFormat = TextFormat.None;
+  private _regexPattern: string | null = null;
 
+  private readonly _dialogService = inject(DialogService);
   private readonly _stringFormatService = inject(StringFormatService);
 
   public getInput(): ElementRef<HTMLElement> | null {
@@ -37,6 +43,21 @@ export class TextBoxPlainComponent extends TextBoxComponent {
 
   public callCtrlLeave(event: any): void {
     if (this.isEditable) {
+      if (this._regexPattern != null && this.value != null && this.value.length > 0) {
+        if (!this.matchesFull(this.value, this._regexPattern)) {
+          this._dialogService.showMsgBox({
+            title: 'Validierung',
+            message: `Der eingegebene Wert entspricht nicht dem erwarteten Format.\n\nErwartetes Format: ${this._regexPattern}`,
+            icon: MsgBoxIcon.Exclamation,
+            buttons: MsgBoxButtons.Ok,
+            defaultButton: MsgBoxDefaultButton.First
+          });
+          this.updateComponent();
+          super.callCtrlLeave(event);
+          return;
+        }
+      }
+
       this.updateWrapper();
       super.callCtrlLeave(event);
     }
@@ -62,9 +83,28 @@ export class TextBoxPlainComponent extends TextBoxComponent {
     this.getWrapper().setValue(this.value);
   }
 
+  /**
+  * Prüft, ob der gesamte Wert dem Regex-Pattern entspricht.
+  * Bildet das Verhalten von Java String.matches() nach, welches implizit
+  * den gesamten String gegen das Pattern prüft (Full-Match).
+  * JavaScript RegExp.test() hingegen prüft nur, ob das Pattern irgendwo
+  * im String matcht (Partial-Match). Daher wird das Pattern hier in
+  * ^(?:...)$ gewrappt, um einen Full-Match zu erzwingen.
+  * Vorhandene ^/$ Anker werden vorher entfernt, um doppelte Anker zu vermeiden.
+  */
+  private matchesFull(value: string, pattern: string): boolean {
+    try {
+      const innerPattern: string = pattern.replace(/^\^/, '').replace(/\$$/, '');
+      return new RegExp(`^(?:${innerPattern})$`).test(value);
+    } catch {
+      return true;
+    }
+  }
+
   protected updateData(wrapper: TextBoxPlainWrapper): void {
     super.updateData(wrapper);
     this._format = wrapper.getFormat();
+    this._regexPattern = wrapper.getRegexPattern();
     this.isPasswordField = wrapper.isPasswordField();
     this.value = this.formatValue(wrapper.getValue());
   }

--- a/src/app/services/controls.service.ts
+++ b/src/app/services/controls.service.ts
@@ -111,8 +111,9 @@ export class ControlsService {
       case TextFormat.Integer:
       case TextFormat.PositiveInteger:
       case TextFormat.NegativeInteger:
-      case TextFormat.UserDefined:
         return TextBoxType.Number;
+      case TextFormat.UserDefined:
+        return propertyStore.getIsFormatPatternRegex() ? TextBoxType.Plain : TextBoxType.Number;
       case TextFormat.DateTimeShort:
       case TextFormat.DateTimeMedium:
       case TextFormat.DateTimeLong:

--- a/src/app/services/formatter/base-format.service.ts
+++ b/src/app/services/formatter/base-format.service.ts
@@ -12,13 +12,17 @@ export class BaseFormatService {
   private readonly _numberFormatService = inject(NumberFormatService);
   private readonly _stringFormatService = inject(StringFormatService);
 
-  public formatString(value: string, parseMethod: ParseMethod, format: TextFormat, formatPattern: string | null): string | null {
+  public formatString(value: string, parseMethod: ParseMethod, format: TextFormat, formatPattern: string | null, isFormatPatternRegex: boolean = false): string | null {
     switch (format) {
       case TextFormat.Decimal:
       case TextFormat.Integer:
       case TextFormat.PositiveInteger:
       case TextFormat.NegativeInteger:
+        return this._numberFormatService.formatString(value, parseMethod, format, formatPattern);
       case TextFormat.UserDefined:
+        if (isFormatPatternRegex) {
+          return this._stringFormatService.formatString(value, format);
+        }
         return this._numberFormatService.formatString(value, parseMethod, format, formatPattern);
       case TextFormat.DateTimeShort:
       case TextFormat.DateTimeMedium:

--- a/src/app/wrappers/textbox-plain-wrapper.ts
+++ b/src/app/wrappers/textbox-plain-wrapper.ts
@@ -18,6 +18,14 @@ export class TextBoxPlainWrapper extends TextBoxBaseWrapper {
     return pwChar != null && pwChar.trim().length > 0;
   }
 
+  public getRegexPattern(): string | null {
+    if (!this.getPropertyStore().getIsFormatPatternRegex()) {
+      return null;
+    }
+    const formatPattern: string | undefined = this.getPropertyStore().getFormatPattern();
+    return formatPattern != null && formatPattern.trim().length > 0 ? formatPattern : null;
+  }
+
   public getValue(): string | null {
     return this.value;
   }


### PR DESCRIPTION
## Zusammenfassung der Änderungen: FormatPattern Regex-Validierung für String-Felder

### Problem

Wenn auf dem Server für ein **String/FSstring**-Feld ein FormatPattern als Regex hinterlegt wird (z.B. `^(?:[0-9]{12,14}|[0-9]{8})`), wurde dieses im HtmlClient fälschlicherweise als **Zahlenformat-Pattern** interpretiert. Der `NumberFormatService` behandelte dabei Zeichen wie `0` als Digit-Platzhalter und `,` als Gruppierungs-Separator, wodurch der angezeigte Wert verstümmelt wurde (z.B. `^(?:[1345345456456-9]{1214}|[-9]{8})` statt `13453454564564`).

Im Java-Client funktioniert die Regex-Validierung korrekt, da dort `String.matches()` verwendet wird.

---

### Geänderte Dateien

#### 1. `src/app/services/controls.service.ts`
- **Was:** Bei `TextFormat.UserDefined` wird nun geprüft, ob das FormatPattern ein Regex ist
- **Warum:** Regex-Patterns dürfen nicht als Number-TextBox gerendert werden
- **Wie:** `propertyStore.getIsFormatPatternRegex()` steuert die Weiche zwischen `TextBoxType.Plain` und `TextBoxType.Number`

#### 2. `src/app/common/property-store.ts`
- **Was:** Neue Methode `getIsFormatPatternRegex()`
- **Warum:** Zentrale Erkennung, ob ein FormatPattern ein Regex ist (anhand von `^`, `(?`, `\\` am Anfang)

#### 3. `src/app/wrappers/textbox-plain-wrapper.ts`
- **Was:** Neue Methode `getRegexPattern()`
- **Warum:** Stellt das rohe FormatPattern bereit (ohne `javaToMoment`-Konvertierung, die den Regex zerstören würde)

#### 4. `src/app/controls/textboxes/textbox-plain/textbox-plain.component.ts`
- **Was:** Regex-Validierung bei `callCtrlLeave` + MsgBox bei Fehlschlag
- **Warum:** Eingabe wird gegen das Regex-Pattern validiert, wie im Java-Client
- **Besonderheit:** `matchesFull()`-Methode bildet Java `String.matches()` nach — JavaScript `RegExp.test()` prüft nur Partial-Match, daher wird das Pattern in `^(?:...)$` gewrappt, um einen Full-Match zu erzwingen. Bei ungültigem Regex wird `true` zurückgegeben (fail-open), damit fehlerhafte Patterns die Eingabe nicht blockieren.

#### 5. `src/app/services/formatter/base-format.service.ts`
- **Was:** Bei `TextFormat.UserDefined` + Regex-Pattern wird der Wert an den `StringFormatService` statt an den `NumberFormatService` weitergeleitet
- **Warum:** Absicherung für ListView/TemplateControl — auch dort darf ein Regex-Pattern nicht durch den Number-Formatter laufen
- **Wie:** Neuer Parameter `isFormatPatternRegex` in `formatString()`

---

### Validierungsverhalten

| Eingabe | Pattern | Ergebnis |
|---|---|---|
| `13453454564564` (14 Zeichen) | `^(?:[0-9]{12,14}\|[0-9]{8})` | Valide |
| `12345678` (8 Zeichen) | `^(?:[0-9]{12,14}\|[0-9]{8})` | Valide |
| `1345345456` (10 Zeichen) | `^(?:[0-9]{12,14}\|[0-9]{8})` | **Invalide** → MsgBox + Reset |
| `abc` | `^(?:[0-9]{12,14}\|[0-9]{8})` | **Invalide** → MsgBox + Reset |
